### PR TITLE
[DEV-2073] Remove the numbered list tip with "Foo" and "Bar."

### DIFF
--- a/askbot/templates/widgets/markdown_help.html
+++ b/askbot/templates/widgets/markdown_help.html
@@ -25,11 +25,6 @@
 
         </li>
         <li>
-        {% trans %}numbered list:{% endtrans %}
-            1.  Foo
-            2.  Bar
-        </li>
-        <li>
         {% trans %}basic HTML tags are also supported{% endtrans %}
         </li>
     </ul>


### PR DESCRIPTION
@mwhansen review?

A request from Jessica.  Honestly, we could consider removing this entire sidebar, because the average Rover user is probably not likely to know how to use markdown.
