### PR TITLE
[DEV-5016] Show categories in secondary header on mobile

### DIFF
--- a/askbot/media/style/style.css
+++ b/askbot/media/style/style.css
@@ -4417,7 +4417,6 @@ td.setting-input textarea {
   .counts .votes,
   .help,
   .rss,
-  .scope-selector,
   .settings,
   .tabBar,
   .tags,
@@ -4527,8 +4526,17 @@ td.setting-input textarea {
   .short-summary {
     width: 100%;
   }
+  #secondaryHeader {
+    height: 109px;
+  }
   #secondaryHeader td.search-bar {
     padding: 0 6px;
+  }
+  #homeButton {
+    padding-top: 15px;
+  }
+  #searchBar {
+    margin-top: 10px;
   }
 }
 @media screen and (max-width: 540px) {

--- a/askbot/templates/widgets/secondary_header.html
+++ b/askbot/templates/widgets/secondary_header.html
@@ -20,31 +20,50 @@
             {% endif %}
             class="{{ enabled_scopes_class }}"
             method="get">
-            {# 
-                A single row table to help the semi-fixed width layout where:
-                * all cells have "tight width" without linebreaks
-                * except that the search bar cell takes the remaining width
-                We had hard time making this layout work without tables.
-                Please suggest if there is a better way.
-            #}
-            <table width="100%">
-                <tr>
-                    {# width 1 means that cell will expand just enough to fit the contents #}
-                    <td width="1">
-                        <a id="homeButton" href="{% url questions %}">
-                            <i class="rover-icon rover-icon-house"></i>
-                        </a>
-                    </td>
-                    <td width="1">{% include "widgets/scope_nav.html" %}</td>
-                    {# width * means that the cell takes the remaining table width #}
-                    <td width="*" class="search-bar">{% include "widgets/search_bar.html" %}</td> 
-                    {% if settings.ASK_BUTTON_ENABLED %}
-                    <td width="1">
-                        {% include "widgets/ask_button.html" %}            
-                    </td>
-                    {% endif %}
-                </tr>
-            </table>
+            <div class="hidden-xs visible-sm visible-md visible-lg">
+                {#
+                    For non-mobile screens:
+                    A single row table to help the semi-fixed width layout where:
+                    * all cells have "tight width" without linebreaks
+                    * except that the search bar cell takes the remaining width
+                    We had hard time making this layout work without tables.
+                    Please suggest if there is a better way.
+                #}
+                <table width="100%">
+                    <tr>
+                        {# width 1 means that cell will expand just enough to fit the contents #}
+                        <td width="1">
+                            <a id="homeButton" href="{% url questions %}">
+                                <i class="rover-icon rover-icon-house"></i>
+                            </a>
+                        </td>
+                        <td width="1">{% include "widgets/scope_nav.html" %}</td>
+                        {# width * means that the cell takes the remaining table width #}
+                        <td width="*" class="search-bar">{% include "widgets/search_bar.html" %}</td>
+                        {% if settings.ASK_BUTTON_ENABLED %}
+                        <td width="1">
+                            {% include "widgets/ask_button.html" %}
+                        </td>
+                        {% endif %}
+                    </tr>
+                </table>
+            </div>
+            <div class="visible-xs hidden-sm hidden-md hidden-lg">
+                {# For mobile, a two-row table with the scope nav below and no button #}
+                <table width="100%">
+                    <tr>
+                        <td width="1">
+                            <a id="homeButton" href="{% url questions %}">
+                                <i class="rover-icon rover-icon-house"></i>
+                            </a>
+                        </td>
+                        <td width="*" class="search-bar">{% include "widgets/search_bar.html" %}</td>
+                    </tr>
+                    <tr>
+                        <td colspan="2">{% include "widgets/scope_nav.html" %}</td>
+                    </tr>
+                </table>
+            </div>
         </form>
     </div>
 </div>


### PR DESCRIPTION
@empanda please review and +1.  This got hairy trying to use Bootstrap's `push` and `pull` classes, so I went with the nuclear option of separate `secondaryHeader`s for mobile and non-mobile.  LMK if you'd like me to try some more playing with it in-place.

https://roverdotcom.atlassian.net/browse/DEV-5016