### PR TITLE
[rover-login-url] We need ROVER_LOGIN_URL in the context

### DIFF
--- a/askbot/context.py
+++ b/askbot/context.py
@@ -50,6 +50,7 @@ def application_settings(request):
     my_settings['USING_RUNSERVER'] = 'runserver' in sys.argv
     my_settings['ASKBOT_VERSION'] = askbot.get_version()
     my_settings['LOGIN_URL'] = url_utils.get_login_url()
+    my_settings['ROVER_LOGIN_URL'] = getattr(settings, 'ROVER_LOGIN_URL', '')
     my_settings['LOGOUT_URL'] = url_utils.get_logout_url()
 
     if my_settings['EDITOR_TYPE'] == 'tinymce':


### PR DESCRIPTION
FYI @mwhansen we need this to work.