### PR TITLE
[DEV-15231] Properly escapes user added comments

### DIFF
--- a/askbot/media/js/post.js
+++ b/askbot/media/js/post.js
@@ -1726,8 +1726,26 @@ SimpleEditor.prototype.getText = function () {
     return $.trim(this._textarea.val());
 };
 
+// Handle escaping user input, from mustache.js
+var entityMap = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+    '/': '&#x2F;',
+    '`': '&#x60;',
+    '=': '&#x3D;'
+};
+
+function escapeHtml (string) {
+    return String(string).replace(/[&<>"'`=\/]/g, function fromEntityMap (s) {
+        return entityMap[s];
+    });
+}
+
 SimpleEditor.prototype.getHtml = function () {
-    return '<div class="transient-comment"><p>' + this.getText() + '</p></div>';
+    return '<div class="transient-comment"><p>' + escapeHtml(this.getText()) + '</p></div>';
 };
 
 SimpleEditor.prototype.setText = function (text) {


### PR DESCRIPTION
@Jaidan - PR & 👍  

@mwhansen - for awareness

This resolves the XSS issue within Askbot comments. I'm using some code here from mustache.js. Ideally, Askbot would be using Django templates for this comment functionally but they are not. Once approved, I'll also submit a PR to Askbot directly, as this exists in the master project as well.

Thanks!