### PR TITLE
[DEV-38741] dont flush session before posting anonymous, and ensure session key exists

### DIFF
--- a/askbot/views/writers.py
+++ b/askbot/views/writers.py
@@ -273,8 +273,11 @@ def ask(request):#view used to ask a new question
                     return HttpResponseRedirect(reverse('index'))
 
             else:
-                request.session.flush()
                 session_key=request.session.session_key
+
+                if not session_key:
+                    session_key = request.session.create()
+
                 models.AnonymousQuestion.objects.create(
                     session_key=session_key,
                     title=title,
@@ -285,7 +288,7 @@ def ask(request):#view used to ask a new question
                     added_at=timestamp,
                     ip_addr=request.META.get('REMOTE_ADDR'),
                 )
-                return HttpResponseRedirect(url_utils.get_login_url())
+                return HttpResponseRedirect(settings.ROVER_LOGIN_URL)
 
     if request.method == 'GET':
         form = forms.AskForm(user=request.user)


### PR DESCRIPTION
This preserves the existing session key, as well as redirects to our signin, versus this *very* old one (it had an AOL sign up option....). So even if the redirect doesn't persist the question, it will at least log them in and allow them to actually ask as authenticated.

This has been broken for a couple years